### PR TITLE
Enable OSV vulnerability scanning and auto-patching

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -92,8 +92,8 @@
         },
         {
             "description": "Prioritize and automerge vulnerability remediation PRs",
-            "matchCategories": [
-                "vulnerability"
+            "matchJsonata": [
+                "vulnerabilityFixVersion != null"
             ],
             "labels": [
                 "security"

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -20,6 +20,13 @@
         "mergeConfidence:all-badges",
         "replacements:all"
     ],
+    "osvVulnerabilityAlerts": true,
+    "vulnerabilityAlerts": {
+        "automerge": true,
+        "labels": [
+            "security"
+        ]
+    },
     "timezone": "America/Los_Angeles",
     "rangeStrategy": "replace",
     "commitBodyTable": true,
@@ -82,6 +89,21 @@
             ],
             "automerge": true,
             "automergeType": "branch"
+        },
+        {
+            "description": "Prioritize and automerge vulnerability remediation PRs",
+            "matchCategories": [
+                "vulnerability"
+            ],
+            "labels": [
+                "security"
+            ],
+            "automerge": true,
+            "automergeType": "pr",
+            "prPriority": 10,
+            "schedule": [
+                "at any time"
+            ]
         },
         {
             "description": "Automerge npm devDependencies (minor/patch) directly to main",


### PR DESCRIPTION
## Summary
- Enables `osvVulnerabilityAlerts` so Renovate proactively creates PRs for dependencies with known vulnerabilities in the OSV database, even outside normal update schedules.
- Adds a `security` label to all vulnerability alert PRs for visibility.
- Adds a package rule that gives vulnerability-fix PRs highest priority (`prPriority: 10`), unrestricted schedule, and automerge via PR.

## Test plan
- [ ] Verify Renovate picks up the new config on next scheduled run
- [ ] Confirm vulnerability PRs appear with the `security` label
- [ ] Confirm vuln-fix PRs automerge after status checks pass