### PR TITLE
feat: add reusable CI workflows (node-build, codeql, stale, npm-release)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+---
+# Reusable workflow: CodeQL advanced analysis for a single language.
+# Trigger events (push / pull_request / schedule) and branch filters are
+# defined by the caller. Multi-language repos should call this once per
+# language.
+name: CodeQL Advanced
+on:
+  workflow_call:
+    inputs:
+      language:
+        description: CodeQL language (e.g. javascript-typescript, java-kotlin)
+        required: false
+        type: string
+        default: javascript-typescript
+      build-mode:
+        description: CodeQL build mode (none, autobuild, manual)
+        required: false
+        type: string
+        default: none
+      runs-on:
+        description: Runner label
+        required: false
+        type: string
+        default: ubuntu-latest
+jobs:
+  analyze:
+    name: Analyze (${{ inputs.language }})
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          languages: ${{ inputs.language }}
+          build-mode: ${{ inputs.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: '/language:${{ inputs.language }}'

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,0 +1,49 @@
+---
+# Reusable workflow: lint + build a Node.js project across a version matrix.
+# Mirrors the per-repo "Build and Lint" workflow the Homebridge plugins each
+# carried. Trigger events (push / pull_request) are defined by the caller.
+name: Build and Lint
+on:
+  workflow_call:
+    inputs:
+      node-versions:
+        description: JSON array of Node.js versions for the build matrix
+        required: false
+        type: string
+        default: '["20.x", "22.x", "24.x"]'
+      runs-on:
+        description: Runner label
+        required: false
+        type: string
+        default: ubuntu-latest
+jobs:
+  build:
+    runs-on: ${{ inputs.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint the project
+        run: npm run lint
+
+      - name: Build the project
+        run: npm run build
+
+      - name: List, audit, fix outdated dependencies and build again
+        run: |
+          npm list --outdated
+          npm audit || true  # ignore failures
+          npm audit fix || true
+          npm list --outdated
+          npm run build

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,62 @@
+---
+# Reusable workflow: semantic-release for an npm package, authenticating as a
+# GitHub App and publishing to npm with provenance via OIDC trusted publishing.
+#
+# IMPORTANT: npm trusted publishing matches on the *caller* workflow's repo and
+# entry-point filename, so consumers must keep their caller workflow named
+# `release.yaml`/`release.yml` (whatever is registered on npmjs.org) and trigger
+# it on push to the release branches. Concurrency is left to the caller.
+name: Release
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version used for the release job
+        required: false
+        type: string
+        default: '24'
+    secrets:
+      APP_ID:
+        description: GitHub App ID used to mint the release token
+        required: true
+      APP_PRIVATE_KEY:
+        description: GitHub App private key
+        required: true
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
+    steps:
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          # Check out the current branch tip, not github.sha. With
+          # concurrency queueing, a queued run otherwise releases its
+          # trigger SHA and is rejected as non-fast-forward once the
+          # branch has advanced. Pulling the tip turns redundant queued
+          # runs into no-ops instead.
+          ref: ${{ github.ref }}
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - run: npm clean-install
+      - run: npm audit signatures
+      - name: Configure atomic git pushes
+        run: git config --global push.atomic true
+      - run: npm run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,68 @@
+---
+# Reusable workflow: close stale issues and PRs. Defaults match the per-repo
+# stale workflow the Homebridge plugins carried; every knob is overridable.
+# The schedule trigger is defined by the caller.
+name: Close stale issues and PRs
+on:
+  workflow_call:
+    inputs:
+      days-before-stale:
+        required: false
+        type: string
+        default: '30'
+      days-before-close:
+        required: false
+        type: string
+        default: '7'
+      stale-issue-message:
+        required: false
+        type: string
+        default: This issue has no recent activity and will be closed in 7 days. Comment to keep the issue open.
+      stale-pr-message:
+        required: false
+        type: string
+        default: This PR has no recent activity and will be closed in 7 days. Comment or update to keep the PR open.
+      stale-issue-label:
+        required: false
+        type: string
+        default: stale
+      stale-pr-label:
+        required: false
+        type: string
+        default: no-pr-activity
+      exempt-issue-labels:
+        required: false
+        type: string
+        default: work-in-progress,disable-stale-bot,needs-triage
+      exempt-pr-labels:
+        required: false
+        type: string
+        default: work-in-progress,disable-stale-bot,needs-triage
+      close-issue-message:
+        required: false
+        type: string
+        default: No activity in over 30 days, closing.
+      close-pr-message:
+        required: false
+        type: string
+        default: No activity in over 30 days, closing.
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-stale: ${{ inputs.days-before-stale }}
+          days-before-close: ${{ inputs.days-before-close }}
+          stale-issue-message: ${{ inputs.stale-issue-message }}
+          stale-pr-message: ${{ inputs.stale-pr-message }}
+          stale-issue-label: ${{ inputs.stale-issue-label }}
+          stale-pr-label: ${{ inputs.stale-pr-label }}
+          exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
+          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
+          close-issue-message: ${{ inputs.close-issue-message }}
+          close-pr-message: ${{ inputs.close-pr-message }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# jabrown93/.github
+
+User-level defaults shared across all `jabrown93` repositories.
+
+- **Renovate** — shared preset in [`renovate-config.json`](renovate-config.json),
+  consumed via `"extends": ["github>jabrown93/.github//renovate-config.json"]`.
+- **Reusable GitHub Actions workflows** — in [`.github/workflows/`](.github/workflows),
+  consumed via `uses:` (see below).
+
+## Reusable workflows
+
+Each workflow is `on: workflow_call`. The third-party actions inside are pinned
+by commit SHA (with a `# vX.Y.Z` comment that Renovate maintains). Consumers
+**also pin this repo by commit SHA** — some repos require digest-pinned `uses:`
+refs — with a `# vX.Y.Z` comment so Renovate can bump them:
+
+```yaml
+uses: jabrown93/.github/.github/workflows/<name>.yml@<sha> # v1.0.0
+```
+
+Trigger events (`push`, `pull_request`, `schedule`, branch filters) and
+`concurrency` stay in the **caller** — a reusable workflow cannot declare them.
+
+### `node-build.yml` — lint + build a Node.js project
+
+| input | default |
+|---|---|
+| `node-versions` | `'["20.x", "22.x", "24.x"]'` (JSON array) |
+| `runs-on` | `ubuntu-latest` |
+
+```yaml
+name: Build and Lint
+on: [push, pull_request]
+jobs:
+  build:
+    uses: jabrown93/.github/.github/workflows/node-build.yml@<sha> # v1.0.0
+```
+
+### `codeql.yml` — CodeQL advanced analysis (single language)
+
+| input | default |
+|---|---|
+| `language` | `javascript-typescript` |
+| `build-mode` | `none` |
+| `runs-on` | `ubuntu-latest` |
+
+```yaml
+name: CodeQL Advanced
+on:
+  push:
+    branches: [main, beta]
+  pull_request:
+    branches: [main, beta]
+  schedule:
+    - cron: '25 22 * * 5'
+jobs:
+  analyze:
+    uses: jabrown93/.github/.github/workflows/codeql.yml@<sha> # v1.0.0
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+```
+
+### `stale.yml` — close stale issues and PRs
+
+Defaults match the prior per-repo stale config; every knob is overridable
+(`days-before-stale`, `days-before-close`, the messages, the labels). The
+schedule lives in the caller.
+
+```yaml
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+jobs:
+  stale:
+    uses: jabrown93/.github/.github/workflows/stale.yml@<sha> # v1.0.0
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+```
+
+### `npm-release.yml` — semantic-release + npm trusted publishing
+
+| input | default |
+|---|---|
+| `node-version` | `'24'` |
+
+Secrets `APP_ID` and `APP_PRIVATE_KEY` must be passed by the caller.
+
+> npm trusted publishing matches on the **caller** repo + entry-point filename.
+> Keep the caller workflow named as registered on npmjs.org (`release.yaml`),
+> and verify a publish succeeds after converting.
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main, beta]
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  release:
+    uses: jabrown93/.github/.github/workflows/npm-release.yml@<sha> # v1.0.0
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+## Versioning
+
+Releases are tagged `vMAJOR.MINOR.PATCH`. Breaking changes to a workflow's
+inputs/secrets bump the major. Consumers pin a SHA; Renovate proposes the bump.


### PR DESCRIPTION
## What

Adds reusable `workflow_call` workflows so the near-identical CI the Homebridge plugins each carried can be managed centrally:

- `node-build.yml` — Node lint + build matrix
- `codeql.yml` — CodeQL advanced (single language, parameterized)
- `stale.yml` — actions/stale with overridable defaults
- `npm-release.yml` — semantic-release + npm trusted publishing (App-token auth)

All third-party actions are **SHA-pinned** with `# vX.Y.Z` comments (Renovate-maintained). `README.md` documents how consumers call them.

## Consumption

Consumers pin **this repo by commit SHA** (some repos require digest-pinned `uses:`):

```yaml
uses: jabrown93/.github/.github/workflows/node-build.yml@<sha> # v1.0.0
```

## After merge

Tag `v1.0.0` at the merge commit so the SHA pins map to a version Renovate can track. Then the consumer conversions (pilot: homebridge-philips-hue-sync-box) pin to that SHA.

## Notes / risks

- **npm trusted publishing** matches on the *caller* repo + entry-point filename — consumers keep their caller named `release.yaml`; verified on the pilot before fan-out.
- Moving a job into a reusable workflow changes status-check names (`<caller-job> / <reusable-job>`) — branch-protection required-checks may need updating on consumers.
- `dt-sbom` is intentionally **not** centralized here (its OpenBao OIDC role binds `job_workflow_ref`; handled separately).