### PR TITLE
chore(deps): bump pinned actions in reusable workflows to fleet-latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,15 +36,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ inputs.language }}
           build-mode: ${{ inputs.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: '/language:${{ inputs.language }}'

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         node-version: ${{ fromJSON(inputs.node-versions) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -32,12 +32,12 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -54,7 +54,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: ${{ inputs.days-before-stale }}
           days-before-close: ${{ inputs.days-before-close }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by commit SHA (with a `# vX.Y.Z` comment that Renovate maintains). Consumers
 refs — with a `# vX.Y.Z` comment so Renovate can bump them:
 
 ```yaml
-uses: jabrown93/.github/.github/workflows/<name>.yml@<sha> # v1.0.0
+uses: jabrown93/.github/.github/workflows/<name>.yml@<sha> # v1.1.0
 ```
 
 Trigger events (`push`, `pull_request`, `schedule`, branch filters) and
@@ -33,7 +33,7 @@ name: Build and Lint
 on: [push, pull_request]
 jobs:
   build:
-    uses: jabrown93/.github/.github/workflows/node-build.yml@<sha> # v1.0.0
+    uses: jabrown93/.github/.github/workflows/node-build.yml@<sha> # v1.1.0
 ```
 
 ### `codeql.yml` — CodeQL advanced analysis (single language)
@@ -55,7 +55,7 @@ on:
     - cron: '25 22 * * 5'
 jobs:
   analyze:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@<sha> # v1.0.0
+    uses: jabrown93/.github/.github/workflows/codeql.yml@<sha> # v1.1.0
     permissions:
       security-events: write
       packages: read
@@ -76,7 +76,7 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    uses: jabrown93/.github/.github/workflows/stale.yml@<sha> # v1.0.0
+    uses: jabrown93/.github/.github/workflows/stale.yml@<sha> # v1.1.0
     permissions:
       actions: write
       issues: write
@@ -105,7 +105,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/npm-release.yml@<sha> # v1.0.0
+    uses: jabrown93/.github/.github/workflows/npm-release.yml@<sha> # v1.1.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Aligns the SHA-pinned actions in the reusable workflows with the newest versions already running across the consumer repos (discovered while preparing the playstation pilot — the per-repo Renovate bumps had moved ahead of the initial v1.0.0 pins).

| action | v1.0.0 | now |
|---|---|---|
| actions/checkout | v6.0.2 | **v6.0.3** |
| github/codeql-action | v4.35.5 | **v4.36.2** |
| actions/stale | v10.2.0 | **v10.3.0** |
| actions/create-github-app-token | v2.2.2 | **v3.2.0** |
| actions/setup-node | v6.4.0 | v6.4.0 (unchanged) |

This makes converting `homebridge-playstation` a **pure structural change** (local jobs → reusable calls) with zero action-version drift, isolating the centralization mechanism in the pilot. More-stale consumers (onkyo, smartrent) get upgraded to these versions when they convert.

No input/secret interface changes.

## After merge
Tag **v1.1.0** at the merge commit; consumers pin that SHA.