### PR TITLE
fix(renovate): correct customManagers:tfvarsVersion typo (→ tfvarsVersions)

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -19,7 +19,7 @@
         "customManagers:mavenPropertyVersions",
         "mergeConfidence:all-badges",
         "preview:dockerVersions",
-        "customManagers:tfvarsVersion",
+        "customManagers:tfvarsVersions",
         "customManagers:tsconfigNodeVersions"
     ],
     "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Problem

`renovate-config.json` extends a non-existent preset **`customManagers:tfvarsVersion`** (singular). The real built-in preset is **`customManagers:tfvarsVersions`** (plural).

Because this is a shared config (`local>jabrown93/.github:renovate-config`) inherited by every jabrown93 repo, Renovate fails config resolution on **all consumers** with:

> `Cannot find preset's package (customManagers:tfvarsVersion). Note: this is a *nested* preset so please contact the preset author if you are unable to fix it yourself.`

Each repo's run ends with `result: config-validation` and Renovate **stops opening/updating PRs fleet-wide**. This surfaced as the "Action Required: Fix Renovate Configuration" issue on jabrown93/homelab#1321 (and the same error fires for homebridge-playstation, etc. in the renovate-ce worker logs).

## Root cause

Introduced in 45d8d23 ("update renocate settings"), which added `customManagers:tfvarsVersion` alongside the valid `customManagers:tsconfigNodeVersions` and `preview:dockerVersions`.

## Fix

One-char correction: `tfvarsVersion` → `tfvarsVersions`.

Verified the valid preset name against upstream [`renovatebot/renovate` `lib/config/presets/internal/custom-managers.preset.ts`](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/custom-managers.preset.ts) — the only terraform-related key is `tfvarsVersions` (plural). The other two presets in this config (`mavenPropertyVersions`, `tsconfigNodeVersions`) are valid and unchanged.

Once merged, Renovate re-resolves the preset on the next run for every consumer and auto-closes the config-error issues.