### PR TITLE
feat(renovate): auto-merge dhi.io non-major (digest) updates across all repos

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -92,6 +92,23 @@
             "automergeType": "branch"
         },
         {
+            "description": "Auto-merge dhi.io (Docker Hardened Images) digest re-patches across all repos. dhi.io continuously re-patches the same version tag for CVEs, so the pinned digest is the only signal a fix shipped; digest is its own updateType and is NOT matched by the generic minor/patch rules above. Together with those rules this completes non-major auto-merge for dhi.io -- major bumps still require review (renovate-major/needs-review). Gated on all status checks via :automergeRequireAllStatusChecks.",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "/^dhi\\.io//"
+            ],
+            "matchUpdateTypes": [
+                "digest"
+            ],
+            "labels": [
+                "renovate-digest"
+            ],
+            "automerge": true,
+            "automergeType": "branch"
+        },
+        {
             "description": "Prioritize and automerge vulnerability remediation PRs",
             "matchJsonata": [
                 "vulnerabilityFixVersion != null"


### PR DESCRIPTION
## What

Adds a `packageRule` to the shared Renovate preset (`renovate-config.json`) that auto-merges **`dhi.io/*` digest updates** when all status checks pass.

Every repo in the account extends this preset (via either `local>jabrown93/.github:renovate-config` or `github>jabrown93/.github//renovate-config.json`), so this is the single lever that makes the policy global.

## Why

For `dhi.io` (Docker Hardened Images), non-major auto-merge had a gap:

| Update type | Before | After |
|---|---|---|
| major | review (`renovate-major`/`needs-review`) | review (unchanged) |
| minor | auto-merge (generic rule) | auto-merge |
| patch | auto-merge (generic rule) | auto-merge |
| **digest** | **not auto-merged** | **auto-merge** |

`dhi.io` continuously re-patches the **same version tag** for CVEs, so the pinned digest is the only signal a fix shipped. `digest` is its own Renovate `updateType` and is **not** matched by the generic `minor`/`patch` rules — so digest bumps stalled everywhere except `homelab` and `homelab-nexus-proxies`, which each carry a local DHI digest rule. This closes the gap for all other repos.

## Notes

- Major `dhi.io` bumps still require review — unchanged.
- Auto-merge remains gated on **all status checks** (`:automergeRequireAllStatusChecks`, already in this preset).
- `homelab` / `homelab-nexus-proxies` keep their local DHI rule (it also groups the bumps and covers the `ghcr.io/jabrown93/{openbao-tools,wol-proxy,envsubst}` images built *from* dhi bases). This shared rule is redundant-but-consistent there; the local rule's `groupName` still applies.
- Today only `homelab` / `homelab-nexus-proxies` consume `dhi.io`; the rule is dormant elsewhere until a repo adds a dhi.io dependency.