### PR TITLE
fix(renovate): correct custom-manager capture group dataSource -> datasource

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -43,7 +43,7 @@
                 "^.*$"
             ],
             "matchStrings": [
-                "[\"']{0,1}(?<currentValue>[^\\s\"']*)[\"']{0,1}\\s+#\\s+(renovate\\s+)(?<dataSource>[^\\s\"']+)\\s+(?<depName>[^\\s\"']+)"
+                "[\"']{0,1}(?<currentValue>[^\\s\"']*)[\"']{0,1}\\s+#\\s+(renovate\\s+)(?<datasource>[^\\s\"']+)\\s+(?<depName>[^\\s\"']+)"
             ]
         },
         {


### PR DESCRIPTION
## What

Renames the capture group in the first custom (regex) manager from `(?<dataSource>…)` to `(?<datasource>…)`.

```diff
-  "...#\\s+(renovate\\s+)(?<dataSource>[^\\s\"']+)\\s+(?<depName>[^\\s\"']+)"
+  "...#\\s+(renovate\\s+)(?<datasource>[^\\s\"']+)\\s+(?<depName>[^\\s\"']+)"
```

## Why

Renovate's custom managers only recognize the lowercase reserved group name **`datasource`** (or an explicit `datasourceTemplate`). The camelCase `dataSource` is not a recognized group, so this manager could never resolve a datasource for the dependencies it matched (comment-annotated versions like `1.2.3 # renovate <datasource> <depName>`).

`renovate-config-validator` flags it as:

> Regex Managers must contain datasourceTemplate configuration or regex group named datasource

## Validation

- `renovate-config-validator`: this specific error is **gone** after the rename. (The validator's other complaints — `platformCommit` enum and `matchJsonata` — are false positives from an older Renovate the validator resolved; both are valid in current Renovate and are not touched here.)
- JSON validity confirmed.

Separate from #13 (compound-tag versioning); both touch different lines of `renovate-config.json` and merge independently.
