### PR TITLE
feat(renovate): pin GitHub Actions to commit SHA digests

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,6 +4,7 @@
         "config:recommended",
         ":configMigration",
         ":pinDevDependencies",
+        "helpers:pinGitHubActionDigests",
         "abandonments:recommended",
         "npm:unpublishSafe",
         ":rebaseStalePrs",


### PR DESCRIPTION
## What

Adds the [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset to the shared `renovate-config.json` `extends` array.

## Why

The shared preset extends `config:recommended`, which does **not** pin GitHub Action digests. The workflow files in this repo are SHA-pinned by hand, but any tag-only reference (`uses: owner/action@v4`) added in this repo or any repo consuming `local>jabrown93/.github:renovate-config` would stay unpinned.

This preset makes Renovate pin every `github-action` dependency to a full-length commit SHA (keeping the semver tag as a trailing comment) and keep the digest updated. It is the same rule [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) applies, and it satisfies the OpenSSF Scorecard [Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) check — complementing the already-enabled `security:openssf-scorecard` badges.

Preset definition:
\`\`\`json
{ "packageRules": [ { "matchDepTypes": ["action"], "pinDigests": true } ] }
\`\`\`

## Validation

- \`jq empty\` — valid JSON.
- \`renovate-config-validator\` — the preset resolves cleanly and introduces **no** new errors. The three errors the validator reports (\`platformCommit\` string vs boolean, and \`packageRules[5].matchJsonata\`) are **pre-existing on \`main\`** and unrelated to this change.

## Notes / out of scope

Heads up on those two pre-existing validator errors (present on `main`) — likely deprecations from a newer validator version than the config targets. Happy to address them in a follow-up if you'd like.