### PR TITLE
feat: add reusable docker-release.yml workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,182 @@
+---
+# Reusable workflow: semantic-release for a Docker-image repo, authenticating
+# as a GitHub App, then building/pushing/signing a multi-arch image to GHCR.
+#
+# Two jobs so a build/push/sign failure never strands a tagged-but-imageless
+# release: `image` only runs once `release` has published, and re-running just
+# the failed job (GitHub's "re-run failed jobs") reuses `release`'s outputs
+# instead of re-evaluating semantic-release.
+#
+# Trigger events, concurrency, and the version-bump-in-repo step (if any) stay
+# in the caller — see jabrown93/AURA/.github/workflows/release.yml and
+# jabrown93/AURA/.releaserc.js for the richest example (weekly dependency
+# roll-up, :edge tag, manual re-publish escape hatch) this was modeled on.
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Full image ref to build, e.g. ghcr.io/jabrown93/crosswatch
+        required: true
+        type: string
+      dockerfile:
+        description: Path to the Dockerfile
+        required: false
+        type: string
+        default: ./Dockerfile
+      context:
+        description: Docker build context
+        required: false
+        type: string
+        default: .
+      platforms:
+        description: Comma-separated target platforms
+        required: false
+        type: string
+        default: linux/amd64,linux/arm64
+      build-args:
+        description: >-
+          Extra newline-separated build-args, appended after the automatic
+          APP_VERSION=v<version> arg.
+        required: false
+        type: string
+        default: ""
+      extra-plugins:
+        description: >-
+          Newline-separated extra semantic-release plugins (beyond the
+          commit-analyzer/release-notes-generator/changelog/git/github the
+          action ships with), e.g. @semantic-release/exec@7.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      APP_ID:
+        description: GitHub App ID used to mint the release token
+        required: true
+      APP_PRIVATE_KEY:
+        description: GitHub App private key
+        required: true
+
+jobs:
+  release:
+    name: semantic-release
+    runs-on: ubuntu-latest
+    # Skip only on our own [skip ci] version-bump commits. github.event.head_commit
+    # is unset on non-push events (schedule/dispatch), so this is safe there too.
+    if: >-
+      github.event_name != 'push' ||
+      !contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: write # push the version-bump commit, create the tag + GitHub Release
+    outputs:
+      published: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      channel: ${{ steps.semantic.outputs.new_release_channel }}
+    steps:
+      # Mint a token for the release GitHub App. semantic-release pushes the
+      # version-bump commit + tag AS this app, and the branch ruleset grants
+      # that app bypass so the unsigned bump commit clears required
+      # signatures / status checks while ordinary contributors stay gated.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history + tags so semantic-release can find the last release
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        with:
+          extra_plugins: ${{ inputs.extra-plugins }}
+        env:
+          # App token (not the default GITHUB_TOKEN) so the tag + GitHub
+          # Release are created by the app the branch ruleset allows to bypass.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  image:
+    name: Build & push image
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.release.outputs.published == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      IMAGE: ${{ inputs.image }}
+      VERSION: ${{ needs.release.outputs.version }}
+      CHANNEL: ${{ needs.release.outputs.channel }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Build the tag semantic-release just created, not the pushed
+          # commit, so the image matches exactly what was released.
+          ref: v${{ env.VERSION }}
+          persist-credentials: false
+
+      - name: Plan tags
+        id: meta
+        run: |
+          if [[ "${CHANNEL}" == "beta" ]]; then
+            tags="${IMAGE}:beta,${IMAGE}:v${VERSION}"
+          else
+            tags="${IMAGE}:latest,${IMAGE}:v${VERSION}"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: ${{ inputs.platforms }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          platforms: ${{ inputs.platforms }}
+          build-args: |
+            APP_VERSION=v${{ env.VERSION }}
+            ${{ inputs.build-args }}
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v3.1.1"
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build-push-action produced no digest; cannot sign image" >&2
+            exit 1
+          fi
+          cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -91,6 +91,11 @@ jobs:
           fetch-depth: 0 # full history + tags so semantic-release can find the last release
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
+          # Check out the current branch tip, not github.sha. With
+          # concurrency queueing, a queued run otherwise operates on its
+          # trigger SHA and its push is rejected as non-fast-forward once
+          # an earlier queued run has already pushed the bump commit.
+          ref: ${{ github.ref }}
 
       - name: Semantic Release
         id: semantic
@@ -135,9 +140,10 @@ jobs:
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
+        # No `platforms:` input: this action's platforms are binfmt arch
+        # names (e.g. arm64,riscv64), not the Buildx OCI target descriptors
+        # (linux/arm64) `inputs.platforms` holds, so it defaults to `all`.
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          platforms: ${{ inputs.platforms }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/README.md
+++ b/README.md
@@ -116,6 +116,50 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
+### `docker-release.yml` — semantic-release + Docker image publish
+
+| input | default |
+|---|---|
+| `image` | *(required)* full image ref, e.g. `ghcr.io/jabrown93/crosswatch` |
+| `dockerfile` | `./Dockerfile` |
+| `context` | `.` |
+| `platforms` | `linux/amd64,linux/arm64` |
+| `build-args` | `""` (extra newline-separated args, appended after the automatic `APP_VERSION=v<version>`) |
+| `extra-plugins` | `""` (extra semantic-release plugins beyond commit-analyzer/release-notes-generator/changelog/git/github) |
+
+Secrets `APP_ID` and `APP_PRIVATE_KEY` must be passed by the caller. Two jobs
+(`release` then `image`) so a build/push/sign failure never strands a
+tagged-but-imageless release — re-run just the failed `image` job and it
+reuses `release`'s outputs instead of re-evaluating semantic-release. The
+image is checked out and built from the release tag itself, tagged `:latest`
++`:v<version>` on `main` or `:beta`+`:v<version>` on a prerelease branch, and
+signed keylessly with cosign. See `jabrown93/AURA/.github/workflows/release.yml`
+for a richer example (weekly dependency roll-up, rolling `:edge` tag, manual
+re-publish) this was modeled on but deliberately left out of the shared
+version — add those as caller-side extensions if a repo needs them.
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main, beta]
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  release:
+    uses: jabrown93/.github/.github/workflows/docker-release.yml@<sha> # v1.2.0
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    with:
+      image: ghcr.io/jabrown93/<repo>
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
 ## Versioning
 
 Releases are tagged `vMAJOR.MINOR.PATCH`. Breaking changes to a workflow's


### PR DESCRIPTION
## Summary
- New reusable `docker-release.yml`: semantic-release (GitHub App auth) + multi-arch Docker build/push/sign to GHCR, matching the existing `npm-release.yml` pattern.
- Two jobs (`release` → `image`) so a build/push/sign failure never strands a tagged-but-imageless release — re-running just the failed `image` job reuses `release`'s outputs.
- Modeled on `AURA/.github/workflows/release.yml` (the fleet's most mature Docker pipeline), generalized behind `workflow_call` inputs (`image`, `dockerfile`, `context`, `platforms`, `build-args`, `extra-plugins`). Deliberately leaves out AURA-specific extras (weekly dependency roll-up, rolling `:edge` tag, manual re-publish dispatch input) — those stay caller-side if a repo wants them.
- README updated with the new workflow's docs + usage snippet.

Intended first consumers: `crosswatch` and `artwork-uploader-plex`, which currently only build images on a manually-pushed tag with no automated versioning.

## Test plan
- [x] `yq eval '.' .github/workflows/docker-release.yml` — valid YAML
- [ ] After merge: tag `v1.2.0`
- [ ] Wire up in `crosswatch`/`artwork-uploader-plex` and confirm a real `push: beta` run publishes a prerelease image