### PR TITLE
fix(workflows): use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -82,7 +82,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`, which was causing deprecation warnings on every `Release` workflow run.
- Both inputs are read identically internally (`core.getInput("client-id") || core.getInput("app-id")`) and passed straight through to octokit's `createAppAuth({ appId })`, which accepts either the numeric App ID or the Client ID — so this is a value-preserving rename, no secret changes needed.

## Test plan
- [ ] Confirm the next workflow run using `docker-release.yml` / `npm-release.yml` no longer shows the `app-id` deprecation warning and still mints a valid app token