### PR TITLE
feat(node-build): check formatting in CI

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Lint the project
         run: npm run lint
 
+      # Consumers run `prettier --check .` from prepublishOnly, which gates the
+      # npm publish rather than the PR: a formatting nit fails the release after
+      # semantic-release has already committed, tagged and pushed. Check it here
+      # so it blocks the PR instead, and publishing only builds the artifact.
+      - name: Check formatting
+        run: npm run prettier
+
       - name: Build the project
         run: npm run build
 


### PR DESCRIPTION
## Why

Consumers enforce `prettier --check .` from `prepublishOnly`, so it gates **`npm publish`** rather than the pull request. That's the wrong place.

By the time `npm publish` runs, semantic-release has already **committed the release, tagged it, and pushed** — `@semantic-release/git` commits during `prepare`, and the tag is created before the publish plugins run. So a formatting nit doesn't fail the PR, it **half-releases the package**: tag and CHANGELOG land, npm never gets the version.

Not hypothetical: `homebridge-philips-hue-sync-box` has **no 3.x on npm at all** (`latest` is still `2.3.0`) while `3.0.0`–`3.0.5` are all tagged, changelogged, and have GitHub history.

## Why here and not just deleted

CI currently runs `lint` and `build` but **never `prettier`** — so moving the check out of `prepublishOnly` without adding it here would drop the check entirely. The pre-commit hook isn't sufficient: it's bypassable with `--no-verify` and doesn't cover Renovate or web-UI commits. That's exactly how an unformatted `.github/workflows/pr-license-comment.yml` reached `main` in **four repos at once**.

## Change

```diff
       - name: Lint the project
         run: npm run lint
 
+      - name: Check formatting
+        run: npm run prettier
+
       - name: Build the project
         run: npm run build
```

Sits next to the existing `lint` step. All four current consumers define a `prettier` script:

| Repo | `prettier` script |
|---|---|
| homebridge-philips-hue-sync-box | `prettier --check .` |
| homebridge-onkyo | `prettier --check .` |
| homebridge-smartrent | `prettier --check .` |
| homebridge-playstation | `prettier --check . \|\| exit 0` ← no-op, fixed in its own PR |

## Rollout

Consumers pin this workflow by SHA (`71c3af9` / v1.2.0), so this has **no effect until they re-pin**. Sequence:

1. Merge this, tag `v1.3.0` (note `main` also has the unreleased `client-id` fix from #23).
2. Re-pin the four consumer repos (Renovate will offer it, or by hand).

The four consumer PRs that drop `prepublishOnly` also run `prettier --write .` across each repo, so they're already clean and won't fail this check when they do re-pin.