### PR TITLE
feat: add generate-sbom action and dt-sbom-upload workflow

### DIFF
--- a/.github/actions/generate-sbom/action.yaml
+++ b/.github/actions/generate-sbom/action.yaml
@@ -1,0 +1,135 @@
+---
+# Composite action: generate a CycloneDX SBOM of the checked-out repo's resolved
+# dependencies and upload it as a workflow artifact.
+#
+# Used by BOTH halves of the Dependency-Track setup -- the push-to-main SBOM
+# upload (dt-sbom-upload.yml's caller) and the advisory PR license check -- which
+# need an identical SBOM and differ only in what they do with it. Each OSS repo
+# previously inlined these same steps twice.
+#
+# ALWAYS run this on a hosted runner. `npm ci` and `mvn` execute dependency
+# lifecycle scripts and build plugins; that code is UNTRUSTED and must never
+# touch an in-cluster runner. See github.com/jabrown93/homelab ->
+# docs/dependency-track.md.
+#
+# The caller checks out the repo first, so it controls fetch-depth.
+#
+# The artifact always holds sbom.cdx.json at its ROOT: upload-artifact flattens a
+# single-file path to its basename, so Maven's target/sbom.cdx.json still arrives
+# as sbom.cdx.json for the consumer. Consumers therefore never parameterize the
+# filename -- only this generator knows where the SBOM was written.
+name: Generate CycloneDX SBOM
+description: >-
+  Generate a CycloneDX SBOM of the checked-out repo's resolved dependencies
+  (npm, maven, or a syft filesystem scan) and upload it as a workflow artifact.
+inputs:
+  ecosystem:
+    description: 'Dependency ecosystem: npm, maven, or syft (filesystem scan).'
+    required: true
+  sbom-path:
+    description: >-
+      Path the generator writes the SBOM to. Maven emits under target/ per the
+      pom's cyclonedx-maven-plugin outputName, so maven callers normally pass
+      target/sbom.cdx.json. The path is a property of the caller's build config,
+      not something this action can infer.
+    required: false
+    default: sbom.cdx.json
+  artifact-name:
+    description: Name of the uploaded artifact.
+    required: false
+    default: sbom
+  node-version:
+    description: Node.js version (ecosystem npm).
+    required: false
+    default: '24'
+  cyclonedx-npm-version:
+    description: Version of @cyclonedx/cyclonedx-npm to run (ecosystem npm).
+    required: false
+    default: 4.2.1
+  java-version:
+    description: JDK version (ecosystem maven).
+    required: false
+    default: '25'
+  java-distribution:
+    description: JDK distribution (ecosystem maven).
+    required: false
+    default: corretto
+runs:
+  using: composite
+  steps:
+    - name: Validate ecosystem
+      # Fail loudly here rather than silently uploading nothing: every generate
+      # step below is `if`-gated, so an unknown value would skip them all and
+      # only surface as upload-artifact's if-no-files-found.
+      shell: bash
+      env:
+        ECOSYSTEM: ${{ inputs.ecosystem }}
+      run: |
+        set -euo pipefail
+        case "${ECOSYSTEM}" in
+          npm | maven | syft) ;;
+          *)
+            echo "::error::unsupported ecosystem '${ECOSYSTEM}' (expected: npm, maven, syft)"
+            exit 1
+            ;;
+        esac
+
+    - name: Set up Node.js
+      if: inputs.ecosystem == 'npm'
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: Install dependencies
+      if: inputs.ecosystem == 'npm'
+      shell: bash
+      run: npm ci
+
+    - name: Generate CycloneDX SBOM (npm)
+      if: inputs.ecosystem == 'npm'
+      shell: bash
+      env:
+        CYCLONEDX_NPM_VERSION: ${{ inputs.cyclonedx-npm-version }}
+        SBOM_PATH: ${{ inputs.sbom-path }}
+      run: |
+        set -euo pipefail
+        # --ignore-npm-errors: a messy dependency tree (an invalid peer) must not
+        # abort generation.
+        npx --yes "@cyclonedx/cyclonedx-npm@${CYCLONEDX_NPM_VERSION}" \
+          --ignore-npm-errors \
+          --output-format JSON \
+          --output-file "${SBOM_PATH}"
+
+    - name: Set up JDK
+      if: inputs.ecosystem == 'maven'
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      with:
+        distribution: ${{ inputs.java-distribution }}
+        java-version: ${{ inputs.java-version }}
+        cache: maven
+
+    - name: Generate CycloneDX SBOM (maven)
+      if: inputs.ecosystem == 'maven'
+      shell: bash
+      # Aggregate BOM so a multi-module build reports one SBOM for the whole
+      # reactor. Output name/format come from the pom's plugin configuration.
+      run: mvn -B cyclonedx:makeAggregateBom
+
+    - name: Generate CycloneDX SBOM (syft)
+      if: inputs.ecosystem == 'syft'
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        path: .
+        format: cyclonedx-json
+        output-file: ${{ inputs.sbom-path }}
+        # This action uploads its own artifact under a generated name by default;
+        # the step below owns the upload so the name is stable for consumers.
+        upload-artifact: false
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        if-no-files-found: error
+        path: ${{ inputs.sbom-path }}

--- a/.github/workflows/dt-sbom-upload.yml
+++ b/.github/workflows/dt-sbom-upload.yml
@@ -1,0 +1,99 @@
+---
+# Reusable workflow: upload a CycloneDX SBOM artifact to the homelab
+# Dependency-Track instance from an in-cluster runner.
+#
+# Split from SBOM generation because only this half may touch the cluster. The
+# caller generates the SBOM on a hosted runner (see the generate-sbom composite
+# action in this repo) and hands it over as an artifact; this job runs on the
+# caller repo's REPO-scoped arc-oss-<repo> set, exchanges the run's GitHub OIDC
+# token for the Dependency-Track CI key via OpenBao (vault-action), then POSTs
+# the SBOM.
+#
+# Project identity defaults to TRUSTED GitHub context (github.repository /
+# github.sha) -- never anything the generating job produced -- so a compromised
+# dependency can't inject values that get executed on the cluster runner. Under a
+# reusable workflow those contexts still resolve to the CALLER's repo and SHA.
+#
+# The runner is egress-locked to a few in-cluster services, so OpenBao and DT are
+# addressed by their in-cluster Service DNS names, not the public gateway (the LE
+# cert has no in-cluster SAN -> tlsSkipVerify; egress is identity-locked to the
+# OpenBao pods, and pod-to-pod traffic is WireGuard-encrypted).
+#
+# Trigger events stay in the caller. Never call this from a `pull_request` event:
+# it would put fork-controlled code in reach of the in-cluster runner.
+#
+# The caller repo must be in the dt-sbom-upload role's `bound_claims.repository`
+# allowlist AND have an arc-oss-<repo> runner set. The OIDC `repository` claim is
+# the caller's repo, so no role change is needed to adopt this workflow. See
+# github.com/jabrown93/homelab -> docs/dependency-track.md.
+name: Dependency-Track SBOM
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: In-cluster runner label, e.g. arc-oss-homebridge-onkyo
+        required: true
+        type: string
+      artifact-name:
+        description: Artifact holding sbom.cdx.json
+        required: false
+        type: string
+        default: sbom
+      project-name:
+        description: >-
+          Dependency-Track project name. Defaults to github.com/<owner>/<repo>
+          from trusted GitHub context.
+        required: false
+        type: string
+        default: ''
+      project-version:
+        description: >-
+          Dependency-Track project version. Defaults to the caller's commit SHA.
+        required: false
+        type: string
+        default: ''
+      is-latest:
+        description: Mark this version as the project's latest in Dependency-Track.
+        required: false
+        type: string
+        default: 'true'
+jobs:
+  upload:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      id-token: write # mint the OIDC token OpenBao exchanges for the DT key
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-sbom-upload
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/ci/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload SBOM to Dependency-Track
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: ${{ inputs.project-name || format('github.com/{0}', github.repository) }}
+          PROJECT_VERSION: ${{ inputs.project-version || github.sha }}
+          IS_LATEST: ${{ inputs.is-latest }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST http://dependency-track-api-server.dependency-track.svc.cluster.local:8080/api/v1/bom \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
+            -F "isLatest=${IS_LATEST}" \
+            -F "bom=@sbom.cdx.json"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ User-level defaults shared across all `jabrown93` repositories.
   consumed via `"extends": ["github>jabrown93/.github//renovate-config.json"]`.
 - **Reusable GitHub Actions workflows** — in [`.github/workflows/`](.github/workflows),
   consumed via `uses:` (see below).
+- **Composite actions** — in [`.github/actions/`](.github/actions), consumed via
+  `uses:` from a step (see below).
 
 ## Reusable workflows
 
@@ -158,6 +160,108 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+### `dt-sbom-upload.yml` — upload a CycloneDX SBOM to Dependency-Track
+
+| input | default |
+|---|---|
+| `runs-on` | *(required)* in-cluster runner label, e.g. `arc-oss-homebridge-onkyo` |
+| `artifact-name` | `sbom` (must hold `sbom.cdx.json`) |
+| `project-name` | `github.com/<owner>/<repo>` from GitHub context |
+| `project-version` | the caller's commit SHA |
+| `is-latest` | `'true'` |
+
+The privileged half of the Dependency-Track setup — pair it with the
+[`generate-sbom`](#generate-sbom--cyclonedx-sbom-for-npm--maven--syft) composite
+action, which builds the SBOM on a hosted runner and hands it over as an
+artifact. Only this half touches the cluster: it runs on the caller repo's
+REPO-scoped `arc-oss-<repo>` set, exchanges the run's OIDC token for the DT CI
+key via OpenBao, then POSTs the SBOM.
+
+Project identity comes from **trusted** GitHub context, never from anything the
+generating job produced, so a compromised dependency can't inject values that get
+executed on the cluster runner. Those contexts still resolve to the *caller's*
+repo and SHA under a reusable workflow.
+
+**Never call this from a `pull_request` event** — that would put fork-controlled
+code in reach of the in-cluster runner. Use the advisory
+producer/consumer split for PRs instead.
+
+The caller repo must be in the `dt-sbom-upload` OpenBao role's
+`bound_claims.repository` allowlist **and** have an `arc-oss-<repo>` runner set.
+The OIDC `repository` claim is the caller's repo, so adopting this workflow needs
+no role change. See `jabrown93/homelab` → `docs/dependency-track.md`.
+
+```yaml
+name: Dependency-Track SBOM
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha> # v7.0.0
+      - uses: jabrown93/.github/.github/actions/generate-sbom@<sha> # v1.4.0
+        with:
+          ecosystem: npm
+  upload:
+    needs: sbom
+    uses: jabrown93/.github/.github/workflows/dt-sbom-upload.yml@<sha> # v1.4.0
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      runs-on: arc-oss-<repo>
+```
+
+## Composite actions
+
+Pinned and consumed the same way as the workflows above, but referenced from a
+**step** rather than a job:
+
+```yaml
+uses: jabrown93/.github/.github/actions/<name>@<sha> # v1.4.0
+```
+
+### `generate-sbom` — CycloneDX SBOM for npm / maven / syft
+
+| input | default |
+|---|---|
+| `ecosystem` | *(required)* `npm`, `maven`, or `syft` (filesystem scan) |
+| `sbom-path` | `sbom.cdx.json` |
+| `artifact-name` | `sbom` |
+| `node-version` | `'24'` (ecosystem `npm`) |
+| `cyclonedx-npm-version` | `4.2.1` (ecosystem `npm`) |
+| `java-version` | `'25'` (ecosystem `maven`) |
+| `java-distribution` | `corretto` (ecosystem `maven`) |
+
+Generates the SBOM and uploads it as an artifact. Used by **both** the
+push-to-main `dt-sbom-upload.yml` caller and the advisory PR license check, which
+need an identical SBOM and differ only in what they do with it.
+
+**Always run this on a hosted runner.** `npm ci` and `mvn` execute dependency
+lifecycle scripts and build plugins — that code is untrusted and must never touch
+an in-cluster runner. The action does **not** check out the repo; the caller does,
+so it controls `fetch-depth`.
+
+Maven emits under `target/` per the pom's `cyclonedx-maven-plugin` `outputName`,
+so maven callers pass `sbom-path: target/sbom.cdx.json` — the path is a property
+of the caller's build config, not something the action can infer. The artifact
+still arrives holding `sbom.cdx.json` at its **root** either way, because
+`upload-artifact` flattens a single-file path to its basename. Consumers
+therefore never parameterize the filename.
+
+```yaml
+      - uses: actions/checkout@<sha> # v7.0.0
+      - uses: jabrown93/.github/.github/actions/generate-sbom@<sha> # v1.4.0
+        with:
+          ecosystem: maven
+          sbom-path: target/sbom.cdx.json
 ```
 
 ## Versioning


### PR DESCRIPTION
Phase 1 of centralizing the three remaining duplicated Dependency-Track workflow families across the six OSS repos (`homebridge-onkyo`, `homebridge-smartrent`, `homebridge-philips-hue-sync-box`, `homebridge-playstation`, `k8s-leader-elector`, `AURA`) — **~2,012 duplicated lines** total.

This PR is the `.github` side only. **No consumer repo changes yet**, so nothing here can break an existing run.

## Why the duplication exists

From `homelab/scripts/restore-openbao-secrets.sh`:

> A public repo can't call homelab's private reusable workflow, so each inlines the upload; they all read the same DT key via this role.

`jabrown93/.github` is public, which removes that constraint. That's the whole unlock.

## What's here

| file | what |
|---|---|
| `.github/actions/generate-sbom/action.yaml` | composite; `ecosystem: npm \| maven \| syft` → SBOM artifact |
| `.github/workflows/dt-sbom-upload.yml` | reusable; in-cluster OIDC → OpenBao → POST to DT |

Split along the trust boundary the OSS repos already draw: generation is **untrusted** (`npm ci` / `mvn` run dependency lifecycle scripts and build plugins) and stays on a hosted runner; only the upload half touches the cluster.

The composite is used by **both** `dt-sbom.yml` and `pr-license-check.yml`, whose SBOM jobs are byte-identical within each repo today — so this removes 12 copies, not 6.

## Adopting this needs no OpenBao change

The `dt-sbom-upload` role binds `repository` + `repository_id` — **not** `job_workflow_ref`. Per the [OIDC claims reference](https://docs.github.com/en/actions/reference/security/oidc), only `job_workflow_ref` names the *called* workflow; `repository` stays the caller's repo under a reusable workflow. `homelab/.github/workflows/dt-sbom-upload.yaml` already proves this shape in production.

(`pr-license-comment.yml` — the family that *does* bind `job_workflow_ref` — is deliberately deferred to a later phase behind a homelab role change.)

## Notes for review

- Project identity still comes from trusted GitHub context (`github.repository` / `github.sha`), never from anything the generating job produced.
- `tlsSkipVerify: true` and the in-cluster Service DNS addresses are preserved verbatim — the LE cert has no in-cluster SAN.
- `sbom-path` is an explicit input rather than inferred: k8s-leader-elector's `target/sbom.cdx.json` comes from its **pom's** `outputName`, which this action can't know. The artifact still arrives holding `sbom.cdx.json` at its root either way, because `upload-artifact` flattens a single-file path to its basename.
- `anchore/sbom-action` gets `upload-artifact: false` so it doesn't publish a second, generated-name artifact alongside ours (AURA currently gets two).
- `actionlint` clean.

## Verification plan

Merging this alone is inert. Phase 2 pilots `homebridge-onkyo` and verifies a real run mints via OIDC and lands a new DT project version before any fan-out.

Lands as `feat:` → semantic-release cuts **v1.4.0** (v1.3.0 was cut by #24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)