### PR TITLE
feat(release): support weekly dependency roll-up releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -108,10 +108,13 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Read by a consumer's .releaserc.js to promote suppressed fix(deps)
           # commits (routine dependency bumps) into a single patch release on
-          # the caller's weekly schedule trigger, instead of on every push. A
-          # consumer without that opt-in config simply ignores this. See the
-          # README's "Weekly dependency releases" section.
-          RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
+          # the caller's weekly schedule trigger, instead of on every push.
+          # Also true on workflow_dispatch, so a manually-triggered run (e.g.
+          # to sweep a non-default release branch a schedule can't reach) acts
+          # as an on-demand version of the same promotion. A consumer without
+          # that opt-in config simply ignores this. See the README's "Weekly
+          # dependency releases" section.
+          RELEASE_DEPS: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
   image:
     name: Build & push image

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -106,6 +106,12 @@ jobs:
           # App token (not the default GITHUB_TOKEN) so the tag + GitHub
           # Release are created by the app the branch ruleset allows to bypass.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Read by a consumer's .releaserc.js to promote suppressed fix(deps)
+          # commits (routine dependency bumps) into a single patch release on
+          # the caller's weekly schedule trigger, instead of on every push. A
+          # consumer without that opt-in config simply ignores this. See the
+          # README's "Weekly dependency releases" section.
+          RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
 
   image:
     name: Build & push image

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,6 +26,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Skip only on our own [skip ci] version-bump commits. github.event.head_commit
+    # is unset on non-push events (schedule/dispatch), so this is safe there too.
+    if: >-
+      github.event_name != 'push' ||
+      !contains(github.event.head_commit.message, '[skip ci]')
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
@@ -60,3 +65,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Read by a consumer's .releaserc.js to promote suppressed fix(deps)
+          # commits (routine dependency bumps) into a single patch release on
+          # the caller's weekly schedule trigger, instead of on every push. A
+          # consumer without that opt-in config simply ignores this. See the
+          # README's "Weekly dependency releases" section.
+          RELEASE_DEPS: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -67,7 +67,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # Read by a consumer's .releaserc.js to promote suppressed fix(deps)
           # commits (routine dependency bumps) into a single patch release on
-          # the caller's weekly schedule trigger, instead of on every push. A
-          # consumer without that opt-in config simply ignores this. See the
-          # README's "Weekly dependency releases" section.
-          RELEASE_DEPS: ${{ github.event_name == 'schedule' }}
+          # the caller's weekly schedule trigger, instead of on every push.
+          # Also true on workflow_dispatch, so a manually-triggered run (e.g.
+          # to sweep a non-default release branch a schedule can't reach) acts
+          # as an on-demand version of the same promotion. A consumer without
+          # that opt-in config simply ignores this. See the README's "Weekly
+          # dependency releases" section.
+          RELEASE_DEPS: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/README.md
+++ b/README.md
@@ -219,6 +219,70 @@ jobs:
       runs-on: arc-oss-<repo>
 ```
 
+## Weekly dependency releases
+
+`npm-release.yml` and `docker-release.yml` both pass a `RELEASE_DEPS` env var
+(`true` when the caller's trigger was `schedule`) into the semantic-release run.
+It does nothing on its own — a consumer opts in by classifying commits with the
+shared Renovate preset and reading `RELEASE_DEPS` in its own `.releaserc.js`.
+
+**Classification** (from `renovate-config.json`, via `config:recommended`'s
+`:semanticPrefixFixDepsChoreOthers` plus this preset's own rules):
+
+| Change | Commit type | Releases on push? |
+|---|---|---|
+| Runtime dep bump (npm `dependencies`, Maven `compile`/`runtime`/`provided`/`import`/`parent`, Dockerfile **final**-stage image) | `fix(deps)` | Only with `RELEASE_DEPS` opt-in below — otherwise yes, same as today |
+| Dev/test/CI-only (npm `devDependencies`, Maven `test`, Dockerfile builder **stage** image, GitHub Actions, lock-file maintenance) | `chore(...)` | Never |
+| Vulnerability remediation (any dep type) | `fix(security)` | Always, immediately |
+| Feature / fix / breaking change you authored | as written | Always, immediately |
+
+**Opt in** to batching routine `fix(deps)` commits into one weekly patch release
+instead of releasing on every dependency merge:
+
+1. Add a `schedule` trigger to the caller workflow, alongside `push`:
+
+   ```yaml
+   on:
+     push:
+       branches: [main, beta]
+     schedule:
+       - cron: '0 9 * * 1' # Mon 09:00 UTC — weekly dependency roll-up
+   ```
+
+2. Use a `.releaserc.js` (not `.releaserc.json`) so the suppression can read
+   `RELEASE_DEPS` at load time:
+
+   ```js
+   // Runtime dep bumps (fix(deps)) are suppressed on ordinary pushes, then
+   // promoted to a single patch by the weekly RELEASE_DEPS run. fix(security)
+   // and scopeless code fix/feat commits are unaffected by this rule and
+   // release on push as normal. chore(...) (dev/test/CI-only) is never
+   // promoted, so a week with only those changes releases nothing.
+   const releaseDeps = process.env.RELEASE_DEPS === 'true';
+   const depReleaseRules = releaseDeps
+     ? [{ type: 'fix', scope: 'deps', release: 'patch' }]
+     : [{ type: 'fix', scope: 'deps', release: false }];
+
+   module.exports = {
+     branches: ['main'],
+     tagFormat: 'v${version}',
+     plugins: [
+       ['@semantic-release/commit-analyzer', { releaseRules: depReleaseRules }],
+       '@semantic-release/release-notes-generator',
+       ['@semantic-release/github', { successComment: false, failComment: false }],
+       // ...the rest of the repo's existing plugins (changelog, git, npm, ...)
+     ],
+   };
+   ```
+
+A repo that skips step 2 is unaffected: `RELEASE_DEPS` is simply unread, and
+`fix(deps)` keeps releasing on push exactly as it does today. See
+`jabrown93/AURA`'s `.releaserc.js` for a fuller example (it additionally covers
+the version-file/changelog side of a release) — note AURA's version predates
+this convention and also promotes `chore(deps)`/`build(deps)` on its weekly
+run, which would release on a dev-dependency-only week; the `fix(deps)`-only
+rule above is the corrected version.
+
 ## Composite actions
 
 Pinned and consumed the same way as the workflows above, but referenced from a

--- a/README.md
+++ b/README.md
@@ -249,6 +249,15 @@ instead of releasing on every dependency merge:
        - cron: '0 9 * * 1' # Mon 09:00 UTC — weekly dependency roll-up
    ```
 
+   GitHub only fires `schedule` events from the **default branch**, and both
+   reusable workflows check out `${{ github.ref }}` — so this only ever sweeps
+   `main`. A repo that also releases prereleases off `beta` gets no automatic
+   weekly promotion there; `fix(deps)` commits on `beta` stay suppressed until
+   an unrelated `feat`/`fix` lands or someone runs the workflow manually (add
+   `workflow_dispatch: {}` to the caller's `on:` as that escape hatch — see
+   `jabrown93/AURA`'s `version-release.yml`, which has both this same
+   limitation and that same manual trigger).
+
 2. Use a `.releaserc.js` (not `.releaserc.json`) so the suppression can read
    `RELEASE_DEPS` at load time:
 

--- a/README.md
+++ b/README.md
@@ -272,12 +272,19 @@ instead of releasing on every dependency merge:
    // release on push as normal. chore(...) (dev/test/CI-only) is never
    // promoted, so a week with only those changes releases nothing.
    const releaseDeps = process.env.RELEASE_DEPS === 'true';
-   const depReleaseRules = releaseDeps
-     ? [{ type: 'fix', scope: 'deps', release: 'patch' }]
-     : [{ type: 'fix', scope: 'deps', release: false }];
+   const depReleaseRules = [
+     // Must precede the fix(deps) rule below: commit-analyzer takes the
+     // first matching custom rule, so a breaking fix(deps)! (or a
+     // BREAKING CHANGE: footer) still releases major instead of being
+     // caught by the deps suppression/patch rule that follows.
+     { type: 'fix', scope: 'deps', breaking: true, release: 'major' },
+     releaseDeps
+       ? { type: 'fix', scope: 'deps', release: 'patch' }
+       : { type: 'fix', scope: 'deps', release: false },
+   ];
 
    module.exports = {
-     branches: ['main'],
+     branches: ['main', { name: 'beta', prerelease: true }],
      tagFormat: 'v${version}',
      plugins: [
        ['@semantic-release/commit-analyzer', { releaseRules: depReleaseRules }],

--- a/README.md
+++ b/README.md
@@ -253,10 +253,14 @@ instead of releasing on every dependency merge:
    reusable workflows check out `${{ github.ref }}` — so this only ever sweeps
    `main`. A repo that also releases prereleases off `beta` gets no automatic
    weekly promotion there; `fix(deps)` commits on `beta` stay suppressed until
-   an unrelated `feat`/`fix` lands or someone runs the workflow manually (add
-   `workflow_dispatch: {}` to the caller's `on:` as that escape hatch — see
-   `jabrown93/AURA`'s `version-release.yml`, which has both this same
-   limitation and that same manual trigger).
+   an unrelated `feat`/`fix` lands. Add `workflow_dispatch: {}` to the
+   caller's `on:` for an on-demand escape hatch instead — both reusable
+   workflows set `RELEASE_DEPS` on `workflow_dispatch` the same as `schedule`,
+   so manually running the workflow against `beta` promotes its suppressed
+   commits immediately. (This diverges from `jabrown93/AURA`'s
+   `version-release.yml`, whose `workflow_dispatch` does *not* set
+   `RELEASE_DEPS` — a manual run there re-evaluates ordinary push rules only,
+   the same `main`-only gap this section describes.)
 
 2. Use a `.releaserc.js` (not `.releaserc.json`) so the suppression can read
    `RELEASE_DEPS` at load time:

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -129,23 +129,6 @@
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?-(?<compatibility>alpine|debian)(?<build>\\d+)(?:\\.(?<revision>\\d+))?(?:\\.\\d+)?-dev$"
         },
         {
-            "description": "Prioritize and automerge vulnerability remediation PRs. semanticCommitType/Scope override config:recommended's :semanticPrefixFixDepsChoreOthers default (fix(deps) for a runtime dep, chore for a dev dep) with fix(security) for ANY vulnerability fix regardless of dep type -- consumer repos that batch routine fix(deps) commits into a weekly release (see docker-release.yml/npm-release.yml's RELEASE_DEPS) key that suppression on the literal scope 'deps', so a distinct 'security' scope is what keeps a vulnerability fix releasing immediately instead of being caught by that suppression.",
-            "matchJsonata": [
-                "vulnerabilityFixVersion != null"
-            ],
-            "labels": [
-                "security"
-            ],
-            "automerge": true,
-            "automergeType": "pr",
-            "prPriority": 10,
-            "schedule": [
-                "at any time"
-            ],
-            "semanticCommitType": "fix",
-            "semanticCommitScope": "security"
-        },
-        {
             "description": "Automerge npm devDependencies (minor/patch) directly to main",
             "matchManagers": [
                 "npm"
@@ -164,7 +147,7 @@
             "automergeType": "branch"
         },
         {
-            "description": "Classify a Dockerfile's FINAL-stage base image as a runtime dependency, not build tooling. The dockerfile manager's default depType split under :semanticPrefixFixDepsChoreOthers types EVERY FROM instruction chore (neither 'final' nor 'stage' is in that preset's fix list), so a base-image bump would otherwise never release on its own -- wrong for 'final', which IS what ships (an intermediate builder 'stage' image correctly stays chore, unmatched by this rule, since it never reaches the runtime image). Sets the same fix/deps typing a runtime language dependency gets, so final-stage bumps participate in both immediate push-triggered releases and the weekly fix(deps) roll-up the same way.",
+            "description": "Classify a Dockerfile's FINAL-stage base image as a runtime dependency, not build tooling. The dockerfile manager's default depType split under :semanticPrefixFixDepsChoreOthers types EVERY FROM instruction chore (neither 'final' nor 'stage' is in that preset's fix list), so a base-image bump would otherwise never release on its own -- wrong for 'final', which IS what ships (an intermediate builder 'stage' image correctly stays chore, unmatched by this rule, since it never reaches the runtime image). Sets the same fix/deps typing a runtime language dependency gets, so final-stage bumps participate in both immediate push-triggered releases and the weekly fix(deps) roll-up the same way. Deliberately ordered BEFORE the vulnerability rule below: Renovate merges matching packageRules in array order with later rules winning on conflicting keys, so a vulnerability fix that happens to target a final-stage image must be classified here first and then have the vulnerability rule's fix(security) win last -- swapping the order would let this rule's fix(deps) overwrite fix(security) and suppress an immediate security release.",
             "matchManagers": [
                 "dockerfile"
             ],
@@ -173,6 +156,23 @@
             ],
             "semanticCommitType": "fix",
             "semanticCommitScope": "deps"
+        },
+        {
+            "description": "Prioritize and automerge vulnerability remediation PRs. Deliberately the LAST packageRule (Renovate merges matches in array order, later wins) so its semanticCommitType/Scope override every other classification in this file, including the final-stage-image rule above -- a vulnerability fix always commits fix(security) regardless of what dep type it happens to touch. This overrides config:recommended's :semanticPrefixFixDepsChoreOthers default (fix(deps) for a runtime dep, chore for a dev dep): consumer repos that batch routine fix(deps) commits into a weekly release (see docker-release.yml/npm-release.yml's RELEASE_DEPS) key that suppression on the literal scope 'deps', so the distinct 'security' scope is what keeps a vulnerability fix releasing immediately instead of being caught by that suppression.",
+            "matchJsonata": [
+                "vulnerabilityFixVersion != null"
+            ],
+            "labels": [
+                "security"
+            ],
+            "automerge": true,
+            "automergeType": "pr",
+            "prPriority": 10,
+            "schedule": [
+                "at any time"
+            ],
+            "semanticCommitType": "fix",
+            "semanticCommitScope": "security"
         }
     ]
 }

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -129,7 +129,7 @@
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?-(?<compatibility>alpine|debian)(?<build>\\d+)(?:\\.(?<revision>\\d+))?(?:\\.\\d+)?-dev$"
         },
         {
-            "description": "Prioritize and automerge vulnerability remediation PRs",
+            "description": "Prioritize and automerge vulnerability remediation PRs. semanticCommitType/Scope override config:recommended's :semanticPrefixFixDepsChoreOthers default (fix(deps) for a runtime dep, chore for a dev dep) with fix(security) for ANY vulnerability fix regardless of dep type -- consumer repos that batch routine fix(deps) commits into a weekly release (see docker-release.yml/npm-release.yml's RELEASE_DEPS) key that suppression on the literal scope 'deps', so a distinct 'security' scope is what keeps a vulnerability fix releasing immediately instead of being caught by that suppression.",
             "matchJsonata": [
                 "vulnerabilityFixVersion != null"
             ],
@@ -141,7 +141,9 @@
             "prPriority": 10,
             "schedule": [
                 "at any time"
-            ]
+            ],
+            "semanticCommitType": "fix",
+            "semanticCommitScope": "security"
         },
         {
             "description": "Automerge npm devDependencies (minor/patch) directly to main",
@@ -160,6 +162,17 @@
             ],
             "automerge": true,
             "automergeType": "branch"
+        },
+        {
+            "description": "Classify a Dockerfile's FINAL-stage base image as a runtime dependency, not build tooling. The dockerfile manager's default depType split under :semanticPrefixFixDepsChoreOthers types EVERY FROM instruction chore (neither 'final' nor 'stage' is in that preset's fix list), so a base-image bump would otherwise never release on its own -- wrong for 'final', which IS what ships (an intermediate builder 'stage' image correctly stays chore, unmatched by this rule, since it never reaches the runtime image). Sets the same fix/deps typing a runtime language dependency gets, so final-stage bumps participate in both immediate push-triggered releases and the weekly fix(deps) roll-up the same way.",
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "matchDepTypes": [
+                "final"
+            ],
+            "semanticCommitType": "fix",
+            "semanticCommitScope": "deps"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- `npm-release.yml` and `docker-release.yml` now pass `RELEASE_DEPS` (`true` on a `schedule`-triggered run) into semantic-release, so a consumer's `.releaserc.js` can batch routine `fix(deps)` dependency commits into one weekly patch release instead of releasing on every merge.
- Shared `renovate-config.json` now types any vulnerability remediation as `fix(security)` (always immediate, never suppressed by the weekly-batch rule) and a Dockerfile's **final**-stage base image as a runtime dep (`fix(deps)`), so weekly batching and dev/test-only exclusion work consistently for npm, Maven, and Docker consumers.
- `npm-release.yml` gains the same `[skip ci]`/non-push event guard `docker-release.yml` already had.
- README documents the classification table and the two-step opt-in (`schedule` trigger + `.releaserc.js` template).

This repo's own `release.yml`/`.releaserc.json` are unchanged — its releasable unit (pinned action SHAs inside the reusable workflows) is the product and should keep shipping immediately.

Modeled on `jabrown93/AURA`'s existing `RELEASE_DEPS` pattern, with two corrections: AURA's weekly rule also promotes `chore(deps)`/`build(deps)` (so a dev-dependency-only week would release — not wanted here), and AURA has no immediate-security carve-out.

## Test plan
- [x] `renovate-config-validator` passes against `renovate-config.json` + `renovate.json`
- [x] `actionlint` passes on the full `.github/workflows/` tree
- [x] `python3 -c "import json; json.load(open('renovate-config.json'))"` — valid JSON
- [ ] After merge: verify a consumer repo's scheduled run shows `RELEASE_DEPS=true` in the semantic-release job log
- [ ] After a consumer adopts the `.releaserc.js` template: confirm a `fix(deps)`-only branch doesn't release on push, then does release (patch) on the next scheduled run

https://claude.ai/code/session_01SggYbp4cQkiNvBVXGaL9Dz