### PR TITLE
docs(release): correct RELEASE_DEPS config guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,27 @@ instead of releasing on every dependency merge:
    `RELEASE_DEPS` — a manual run there re-evaluates ordinary push rules only,
    the same `main`-only gap this section describes.)
 
-2. Use a `.releaserc.js` (not `.releaserc.json`) so the suppression can read
-   `RELEASE_DEPS` at load time:
+2. Replace `.releaserc.json` with an executable config so the suppression can
+   read `RELEASE_DEPS` at load time. **Delete the `.releaserc.json`** — do not
+   leave it alongside: semantic-release resolves config via cosmiconfig, whose
+   search order puts `.releaserc.json` *before* `.releaserc.js`, so a leftover
+   JSON file silently wins and the new rules never load.
+
+   Pick the extension to match the repo's module system, or the config throws
+   at load:
+
+   | repo | file | export |
+   |---|---|---|
+   | `"type": "module"` in `package.json` | `.releaserc.js` | `export default {...}` |
+   | no `package.json`, or CommonJS | `.releaserc.js` | `module.exports = {...}` |
+   | `"type": "module"` but you want CommonJS | `.releaserc.cjs` | `module.exports = {...}` |
+
+   Using `module.exports` in a `.releaserc.js` under `"type": "module"` fails
+   with `ReferenceError: module is not defined in ES module scope`. It fails
+   loudly at release time rather than silently mis-releasing, but it fails.
+
+   The example below is CommonJS; for an ESM repo swap `module.exports =` for
+   `export default`.
 
    ```js
    // Runtime dep bumps (fix(deps)) are suppressed on ordinary pushes, then
@@ -273,10 +292,13 @@ instead of releasing on every dependency merge:
    // promoted, so a week with only those changes releases nothing.
    const releaseDeps = process.env.RELEASE_DEPS === 'true';
    const depReleaseRules = [
-     // Must precede the fix(deps) rule below: commit-analyzer takes the
-     // first matching custom rule, so a breaking fix(deps)! (or a
-     // BREAKING CHANGE: footer) still releases major instead of being
-     // caught by the deps suppression/patch rule that follows.
+     // Required: commit-analyzer evaluates every matching custom rule and
+     // keeps the highest release type, and a breaking fix(deps)! (or a
+     // BREAKING CHANGE: footer) would otherwise match ONLY the suppression
+     // rule below and never release. Listed first so the analyzer
+     // short-circuits on major; the rules are order-independent, but the
+     // suppression's `release: false` is falsy and only survives when no
+     // other rule matches, so leading with the strongest rule is clearer.
      { type: 'fix', scope: 'deps', breaking: true, release: 'major' },
      releaseDeps
        ? { type: 'fix', scope: 'deps', release: 'patch' }


### PR DESCRIPTION
Follow-up to #27. Found while onboarding the fleet to the weekly dependency roll-up: the step-2 template does not work in the repos most likely to copy it.

## What's wrong

**1. `module.exports` is wrong for every homebridge consumer.** All four (`homebridge-onkyo`, `-smartrent`, `-playstation`, `-philips-hue-sync-box`) set `"type": "module"`. A `.releaserc.js` using `module.exports` there throws:

```
ReferenceError: module is not defined in ES module scope
```

It fails loudly at release time rather than silently mis-releasing, but it fails. Replaced with an extension/export matrix.

**2. `.releaserc.json` shadows `.releaserc.js`.** semantic-release resolves config through `cosmiconfig("release")` with no custom `searchPlaces`, so cosmiconfig's defaults apply — and they list `.releaserc.json` *before* `.releaserc.js`. A repo that adds the new file without deleting the old one gets the JSON silently, and the new rules never load. Now called out explicitly.

**3. The breaking-rule comment states a mechanism that doesn't exist.** It claimed commit-analyzer "takes the first matching custom rule". It does not — per its own `analyze-commit.js` docstring, it finds *all* matching rules and returns the **highest** release type. Verified: swapping the two rules still yields `major`.

The rule itself is still required — without it, `fix(deps)!` matches only the suppression rule and returns `null` — so #27's fix was correct in substance, just not for the stated reason. Comment now explains the real one.

## Verification

Tested against the real `semantic-release@25` / `cosmiconfig@9` / `commit-analyzer@13` resolved in the consumer repos, not from docs:

| config | `type: module` | CommonJS |
|---|---|---|
| `.releaserc.js` + `export default` | works | — |
| `.releaserc.js` + `module.exports` | **ReferenceError** | works |
| `.releaserc.cjs` + `module.exports` | works | works |

And the documented rule matrix behaves exactly as #27 intends:

| commit | on push | on weekly/dispatch |
|---|---|---|
| `fix(deps): bump lodash` | no release | patch |
| `fix(deps)!: …BREAKING` | major | major |
| `fix(security): bump ws` | patch | patch |
| `chore(deps): bump eslint` | no release | no release |

Docs-only — `docs:` cuts no release.