### PR TITLE
ci(renovate): route jabrown93/ci refs to per-component tag streams

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -55,6 +55,22 @@
             "matchStrings": [
                 "[\"']{0,1}(?<depName>[^\\s\"']+):(?<currentValue>[^\\s\"']*)[\"']{0,1}\\s+#\\s+(renovate)"
             ]
+        },
+        {
+            "description": "Route jabrown93/ci reusable-workflow and composite-action refs to their PER-COMPONENT tag stream. jabrown93/ci publishes component-prefixed tags (workflows-v*, generate-sbom-v*, release-checkout-v*); a consumer pins a ref by digest with a matching `# <component>-vX.Y.Z` comment. The built-in github-actions manager sees only the repo `jabrown93/ci` and would collapse every component into one version stream (and mis-sort the prefixed tags as plain semver), so it is disabled for that repo (packageRule below) and this manager owns those refs: it keys each dep on its component (distinct depName -> separate PRs), looks up github-tags on jabrown93/ci, and constrains the candidate versions to that component's prefix via extractVersionTemplate, so a workflows ref can never bump onto a generate-sbom tag. Currently matches nothing until consumers are cut over from jabrown93/.github, so it is safe to land ahead of that.",
+            "fileMatch": [
+                "(^|/)\\.github/workflows/[^/]+\\.ya?ml$",
+                "(^|/)action\\.ya?ml$"
+            ],
+            "matchStrings": [
+                "uses:\\s+jabrown93/ci/(?<packagePath>\\S+)@(?<currentDigest>[0-9a-f]{40})\\s*#\\s*(?<component>workflows|generate-sbom|release-checkout)-v(?<currentValue>[0-9][^\\s]*)"
+            ],
+            "datasourceTemplate": "github-tags",
+            "depNameTemplate": "jabrown93/ci:{{{component}}}",
+            "packageNameTemplate": "jabrown93/ci",
+            "versioningTemplate": "semver",
+            "extractVersionTemplate": "^{{{component}}}-v(?<version>.+)$",
+            "autoReplaceStringTemplate": "uses: jabrown93/ci/{{{packagePath}}}@{{{newDigest}}} # {{{component}}}-v{{{newValue}}}"
         }
     ],
     "npm": {
@@ -63,6 +79,16 @@
         ]
     },
     "packageRules": [
+        {
+            "description": "Disable the built-in github-actions manager for jabrown93/ci refs; the per-component regexManager above owns them. Without this, both managers extract the same `uses:` line and the github-actions one -- which resolves the whole repo's tags as a single stream -- would open duplicate or cross-component PRs.",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchPackageNames": [
+                "jabrown93/ci"
+            ],
+            "enabled": false
+        },
         {
             "matchUpdateTypes": [
                 "major"


### PR DESCRIPTION
## What

Adds Renovate support in the shared preset for the new **`jabrown93/ci`** CI library, which versions each component on its own tag stream (`workflows-v*`, `generate-sbom-v*`, `release-checkout-v*`).

- **New `regexManager`** matches `uses: jabrown93/ci/<path>@<sha> # <component>-vX.Y.Z` refs, keys each dep on its component (distinct `depName` → separate PRs), looks up `github-tags` on `jabrown93/ci`, and constrains candidate versions to that component's prefix via `extractVersionTemplate` — so a `workflows` ref can never bump onto a `generate-sbom` tag.
- **New `packageRule`** disables the built-in `github-actions` manager for `jabrown93/ci`, so the two managers don't both extract the same line (the default one would collapse all components into one mis-sorted stream).

## Why

Part of splitting the shared CI library out of `jabrown93/.github` into `jabrown93/ci` with **per-component versioning**. The default github-actions manager sees only the repo `jabrown93/ci` and can't distinguish components; this manager routes each ref to the right stream.

## Safety

Matches **nothing** today — no repo references `jabrown93/ci` yet (consumers still point at `jabrown93/.github`). Safe to land ahead of the consumer cutover. `renovate-config-validator` passes.

## Note

The validator flags the pre-existing `regexManagers` → `customManagers` migration (from `:configMigration`); this PR does not address that (out of scope) and adds its entry in the existing `regexManagers` array for consistency.