### PR TITLE
fix(renovate): force semanticCommits enabled instead of auto-detect

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -32,6 +32,7 @@
     },
     "timezone": "America/Los_Angeles",
     "rangeStrategy": "replace",
+    "semanticCommits": "enabled",
     "commitBodyTable": true,
     "prHourlyLimit": 10,
     "dependencyDashboardOSVVulnerabilitySummary": "all",


### PR DESCRIPTION
## Summary
- `semanticCommits` was left at Renovate's default `"auto"`, which auto-detects whether a repo uses conventional commits by scoring recent commit messages against the Angular convention (`+1` match / `-1` no match) and only turns prefixing on if the score is `> 0`.
- Consumer repos with mixed git history (e.g. jabrown93/dev-config, whose 3 commits score `-1`) fail that detection, so Renovate silently drops the `type(scope):` prefix on PR titles/commits — even though every `packageRule` in this file already sets `semanticCommitType`/`semanticCommitScope` assuming semantic commits are on.
- Sets `"semanticCommits": "enabled"` at the top level so PR titles are always prefixed, regardless of a given consumer repo's commit history.

Found while investigating why [jabrown93/dev-config#4](https://github.com/jabrown93/dev-config/pull/4) (a Renovate PR) had a plain, non-conventional title.

## Test plan
- [x] `renovate-config-validator renovate-config.json` → `Config validated successfully`
- [ ] Once merged, confirm the next Renovate PR opened against a consumer repo (e.g. dev-config) has a `chore(deps):`/`fix(deps):`-prefixed title