### PR TITLE
fix(renovate): group vitest monorepo packages into one branch

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -12,6 +12,7 @@
         ":maintainLockFilesWeekly",
         ":automergeRequireAllStatusChecks",
         ":combinePatchMinorReleases",
+        "group:vitestMonorepo",
         ":docker",
         "security:openssf-scorecard",
         ":npm",


### PR DESCRIPTION
## Summary
- vitest and its `@vitest/*` siblings (`@vitest/coverage-v8`, `@vitest/ui`, etc.) pin peer dependencies to an exact matching version.
- Renovate currently proposes them as independent branches, which can land `vitest` and e.g. `@vitest/coverage-v8` at mismatched versions and break `npm install` for any consumer repo using vitest for `npm run test` (see `node-build.yml`).
- Adds the built-in `group:vitestMonorepo` preset to the shared `renovate-config.json` so all vitest-monorepo packages are bundled into a single branch/PR and always bump together.

## Test plan
- [x] Validated JSON syntax.
- [x] Confirmed `group:vitestMonorepo` is a real built-in Renovate preset (sourced from `vitest-dev/vitest` monorepo grouping in `lib/data/monorepo.json` upstream), so no custom `matchSourceUrls` packageRule is needed.
- [ ] Watch the next Renovate run on a consumer repo using vitest to confirm the grouped branch/PR appears.