### PR TITLE
feat(renovate): add shared semantic-release preset

### DIFF
--- a/renovate-semantic-release.json
+++ b/renovate-semantic-release.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Dependency constraints for repos that release via semantic-release. Extend alongside renovate-config, not instead of it.",
+    "packageRules": [
+        {
+            "description": "Pinned to v9: v10 builds writerOpts from @conventional-changelog/template JS functions that require conventional-changelog-writer v9, but @semantic-release/release-notes-generator pins conventional-changelog-writer ^8 and silently ignores them, producing heading-only CHANGELOG entries with no commit bodies. Unpin once release-notes-generator supports writer v9.",
+            "matchPackageNames": [
+                "conventional-changelog-conventionalcommits"
+            ],
+            "allowedVersions": "<10.0.0"
+        }
+    ]
+}


### PR DESCRIPTION
Part 1 of a Renovate config audit across all owned repos.

## What

Adds `renovate-semantic-release.json`, a preset holding the
`conventional-changelog-conventionalcommits <10.0.0` constraint.

## Why

That rule is currently copy-pasted verbatim into five repos:

- `homebridge-onkyo`
- `homebridge-playstation`
- `homebridge-smartrent`
- `homebridge-philips-hue-sync-box`
- `dev-config` (same constraint, different rationale in the description)

It is a workaround with a documented removal condition, so it should live
in one place. Follow-up PRs in each of those repos swap the local rule for
`local>jabrown93/.github:renovate-semantic-release`.

Kept out of `renovate-config.json` because it only applies to repos that
release via semantic-release — `homelab` and `ci` do not.

## Verification

`renovate-config-validator` passes.

No behavior change on its own: nothing extends this preset yet.

---
🤖 Authored by Claude (AI agent) at the repo owner's direction.

https://claude.ai/code/session_012gJxRyCGZLCG81R3jNvWes