### PR TITLE
feat(renovate): digest-pin everything by default

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -38,6 +38,7 @@
     "dependencyDashboardOSVVulnerabilitySummary": "all",
     "automergeStrategy": "squash",
     "platformCommit": "enabled",
+    "pinDigests": true,
     "customManagers": [
         {
             "customType": "regex",
@@ -117,7 +118,7 @@
             ]
         },
         {
-            "description": "Collapse digest churn into a single branch. Nearly every image and action in these repos is digest-pinned (pinDigests on the docker managers plus helpers:pinGitHubActionDigests), and upstreams that re-patch a tag in place -- dhi.io, cloudnative-pg, lscr.io -- produce a steady stream of digest-only updates that are individually meaningless. Automerge comes from :automergeDigest. minimumReleaseAge is cleared because a digest re-patch IS the CVE fix; holding it three days would defeat the point, and a digest update frequently carries no release timestamp for the check to read anyway. A repo that wants a narrower grouping (see homelab's ghcr.io/jabrown93 rule) overrides this with a later rule of its own.",
+            "description": "Collapse digest churn into a single branch. Every image and action in these repos is digest-pinned (top-level pinDigests above plus helpers:pinGitHubActionDigests; a repo can still opt a package out with a later pinDigests:false rule), and upstreams that re-patch a tag in place -- dhi.io, cloudnative-pg, lscr.io -- produce a steady stream of digest-only updates that are individually meaningless. Automerge comes from :automergeDigest. minimumReleaseAge is cleared because a digest re-patch IS the CVE fix; holding it three days would defeat the point, and a digest update frequently carries no release timestamp for the check to read anyway. A repo that wants a narrower grouping (see homelab's ghcr.io/jabrown93 rule) overrides this with a later rule of its own.",
             "matchUpdateTypes": [
                 "digest"
             ],

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -144,6 +144,14 @@
             "minimumReleaseAge": null
         },
         {
+            "description": "Trusted publishers: clear the 3-day minimumReleaseAge for ghcr.io/jabrown93/** (self-published -- holding our own CI's output three days serves nothing) and dhi.io/** (Docker Hardened Images; releases are CVE-driven and best taken promptly). Digest and pinDigest updates were already exempt via the rules above; this extends the exemption to tag/version bumps for these prefixes. Unscoped by datasource so it also reaches OCI Helm charts and any other datasource carrying these names.",
+            "matchPackageNames": [
+                "/^ghcr\\.io/jabrown93//",
+                "/^dhi\\.io//"
+            ],
+            "minimumReleaseAge": null
+        },
+        {
             "description": "Track BOTH the application version and the base-OS version in compound Docker tags like 'python:3.14.6-alpine3.24'. Default docker versioning only bumps the leading version and pins the whole suffix, so OS releases (e.g. -alpine3.24 -> -alpine3.25) are never proposed. This regex versioning maps the app version (major.minor[.patch]) plus the OS version (major[.minor]) into the comparable release array, so an increase in EITHER triggers an update; 'compatibility' (alpine|debian) is locked so a dependency never switches OS family -- an alpine tag is never updated to a debian tag and vice versa (the debian variant is simply ignored for an alpine image, and vice versa). OS bumps surface as patch-type updates (build/revision are handled like patch) and thus auto-merge via :automergeMinor, gated on all status checks. matchCurrentValue is kept in lock-step with the versioning regex (same app/OS segment shape, anchored) so it only selects tags this versioning can parse; plain or non-conforming tags (e.g. 3.14.6, latest, 3.14.6-slim) keep default docker versioning. The OS accepts 1-3 segments: major, major.minor, or major.minor.patch -- but because Renovate's regex versioning exposes only 5 comparable numeric slots (major/minor/patch consumed by the app), the OS uses the remaining two (build=OS-major, revision=OS-minor) and a 3rd OS segment is matched but NOT independently compared (so an OS patch-only re-release such as alpine3.20.3 -> alpine3.20.5 is not flagged; OS major/minor still are). Full independent OS-patch tracking would require splitting into two dependencies via custom managers.",
             "matchDatasources": [
                 "docker"


### PR DESCRIPTION
## What

1. Top-level `"pinDigests": true` — every docker-datasource dependency in every consumer repo gets digest-pinned by default. Updates the digest-group rule description to match.
2. New packageRule clearing `minimumReleaseAge` for `ghcr.io/jabrown93/**` and `dhi.io/**` — trusted publishers: self-published images need no 3-day quarantine after our own CI pushes them, and dhi.io releases are CVE-driven, so promptness is the point. Digest/pinDigest updates were already exempt; this extends the exemption to tag/version bumps. Unscoped by datasource, so it also reaches OCI Helm charts (`dhi.io/*-chart`).

## Why

- The preset's digest-group rule already assumed near-total pinning while the pinning itself was scattered across per-repo rules. This makes the assumption true by construction.
- Closes the recurring gap class where an image lands outside a repo's pin-rule scope and silently stops receiving same-tag re-patches (unpinned + `IfNotPresent` = stale cached image) — proven live in jabrown93/homelab#1967 for pgbouncer/openbao-tools.
- Churn cost is already absorbed here: `:automergeDigest`, the grouped "digest updates" branch, `minimumReleaseAge: null` for digest + pinDigest update types.

## Pre-checks done

- Scanned all preset consumers (ci, dev-config, dev-setup, homebridge-philips-hue-sync-box, homelab, nzbget-exporter, tautulli-exporter) for untagged-manifest cleanup workflows that would break pulls of superseded pinned digests: **none exist**.
- Actions already pinned via `helpers:pinGitHubActionDigests`; npm unaffected; managers without digest template support no-op.

## Expected rollout

One-time wave of `pinDigest` PRs across consumer repos on the next Renovate runs — auto-merged per the existing pinDigest rule, runtime no-op (pins the digest the tag currently resolves to).

## Companion

jabrown93/homelab#2345 removes homelab's per-image pin rules and defers to this preset. **Merge this PR first.** Remaining homelab redundancies (dockerfile/docker-compose `pinDigests: true`, M11 helm-values rule) trimmed in a follow-up after this lands.

Validated with `renovate-config-validator`.

*PR authored by an AI agent (Claude).*

https://claude.ai/code/session_01TiJHdZ9fyLd7AY3yUm6snN