### PR TITLE
fix(renovate): rewrite Go import paths on major module updates

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -91,6 +91,10 @@
             "npmDedupe"
         ]
     },
+    "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+    ],
     "packageRules": [
         {
             "description": "Disable the built-in github-actions manager for jabrown93/ci refs; the per-component custom manager above owns them. Without this, both managers extract the same `uses:` line and the github-actions one -- which resolves the whole repo's tags as a single stream -- would open duplicate or cross-component PRs.",


### PR DESCRIPTION
> Written by AI agent (Claude Code).

## Why

AURA's jwx v3-to-v4 Renovate PR kept reopening after every merge (jabrown93/AURA#103, #104, #107). Root cause: without `gomodUpdateImportPaths`, a Go major update only edits the `go.mod` require line — source files keep importing the old module path, so `go mod tidy` re-adds the old major alongside the new one, and Renovate re-detects it on the next scan. Infinite loop.

## What changed

Top-level `postUpdateOptions`:

- `gomodUpdateImportPaths` — rewrites `import` paths in source on major Go module updates (uses marwan-at-work/mod).
- `gomodTidy` — implicit for majors once import-path rewriting is on; explicit so minor/patch updates run `go mod tidy` too.

Validated with `renovate-config-validator` (passes). npm's `npmDedupe` stays scoped under the `npm` block; these Go options are no-ops for non-Go repos consuming this shared config.

Companion fix removing AURA's direct jwx dependency: jabrown93/AURA#108.

https://claude.ai/code/session_01ThfaVpDKA9vAb5fcKtriAq